### PR TITLE
Add subject info deserialization for StreamInfo.

### DIFF
--- a/src/Liftbridge.Net/Metadata.cs
+++ b/src/Liftbridge.Net/Metadata.cs
@@ -73,6 +73,7 @@ namespace Liftbridge.Net
             {
                 CreationTimestamp = DateTime.UnixEpoch.Add(TimeSpan.FromMilliseconds(proto.CreationTimestamp / 1_000_000)),
                 Name = proto.Name,
+                Subject=proto.Subject,
                 Partitions = ImmutableDictionary<int, PartitionInfo>.Empty
                     .AddRange(proto.Partitions.Select((partition, _) =>
                         new KeyValuePair<int, PartitionInfo>(partition.Key, PartitionInfo.FromProto(partition.Value))

--- a/src/Liftbridge.Net/Metadata.cs
+++ b/src/Liftbridge.Net/Metadata.cs
@@ -59,7 +59,7 @@ namespace Liftbridge.Net
     {
         public string Name { get; init; }
         public string Subject { get; init; }
-        public DateTime CreationTimestamp { get; init; }
+        public DateTimeOffset CreationTimestamp { get; init; }
         public ImmutableDictionary<int, PartitionInfo> Partitions { get; init; }
 
         public PartitionInfo GetPartition(int partitionId)
@@ -71,9 +71,9 @@ namespace Liftbridge.Net
         {
             return new StreamInfo
             {
-                CreationTimestamp = DateTime.UnixEpoch.Add(TimeSpan.FromMilliseconds(proto.CreationTimestamp / 1_000_000)),
+                CreationTimestamp = DateTimeOffset.FromUnixTimeMilliseconds(proto.CreationTimestamp / 1_000_000),
                 Name = proto.Name,
-                Subject=proto.Subject,
+                Subject = proto.Subject,
                 Partitions = ImmutableDictionary<int, PartitionInfo>.Empty
                     .AddRange(proto.Partitions.Select((partition, _) =>
                         new KeyValuePair<int, PartitionInfo>(partition.Key, PartitionInfo.FromProto(partition.Value))

--- a/test/Liftbridge.Net.UnitTests/MetadataTests.cs
+++ b/test/Liftbridge.Net.UnitTests/MetadataTests.cs
@@ -14,5 +14,22 @@ namespace Liftbridge.Net.Tests
             var broker = metadata.GetBroker("1");
             Assert.Equal(b, broker);
         }
+
+        [Fact]
+        public void TestDeserializeStreamInfoWithoutPartitions()
+        {
+            var protoStreamInfo = new Proto.StreamMetadata
+            {
+                Name = "test-stream",
+                Subject = "test",
+                CreationTimestamp = 1618912800_000000, // The Liftbridge server uses nanoseconds
+                Error = Proto.StreamMetadata.Types.Error.Ok,
+            };
+
+            var streamInfo = StreamInfo.FromProto(protoStreamInfo);
+            Assert.Equal(protoStreamInfo.Name, streamInfo.Name);
+            Assert.Equal(protoStreamInfo.Subject, streamInfo.Subject);
+            Assert.Equal(protoStreamInfo.CreationTimestamp, streamInfo.CreationTimestamp.ToUnixTimeMilliseconds() * 1_000_000);
+        }
     }
 }


### PR DESCRIPTION
Here's the fix for issue #9. Testing is maybe better implemented as part of full StreamInfo deserialization test.